### PR TITLE
Code needs to treat Mac OS X systems like Unix systems

### DIFF
--- a/dbxsys.c
+++ b/dbxsys.c
@@ -44,7 +44,7 @@
 #define JAN1ST1970 0x19DB1DED53E8000ULL
 #define NSPERSEC 1000000000ULL
 
-#ifdef __APPLE__ || __unix__
+#if defined(__APPLE__) || defined(__unix__)
 
 #include <glob.h>
 #include <sys/types.h>
@@ -95,7 +95,7 @@ static int _sys_set_time(char *filename, time_t timestamp)
   return utime(filename, &timbuf);
 }
 
-#endif /* __unix__ */
+#endif /*  defined(__APPLE__) || defined(__unix__) */
 
 #ifdef _WIN32
 


### PR DESCRIPTION
Without this fix, we see undefined message errors because nothing is
defined for several target dependent methods.

> make
> make  all-am
> gcc -DHAVE_CONFIG_H -I.    -Wall -Werror -g -O2 -MT undbx.o -MD -MP -MF .deps/undbx.Tpo -c -o undbx.o undbx.c
> mv -f .deps/undbx.Tpo .deps/undbx.Po
> gcc -DHAVE_CONFIG_H -I.    -Wall -Werror -g -O2 -MT dbxsys.o -MD -MP -MF .deps/dbxsys.Tpo -c -o dbxsys.o dbxsys.c
> cc1: warnings being treated as errors
> dbxsys.c: In function ‘sys_glob’:
> dbxsys.c:193: warning: implicit declaration of function ‘_sys_glob’
> dbxsys.c:193: warning: assignment makes pointer from integer without a cast
> dbxsys.c: In function ‘sys_mkdir’:
> dbxsys.c:217: warning: implicit declaration of function ‘_sys_mkdir’
> dbxsys.c: In function ‘sys_chdir’:
> dbxsys.c:242: warning: implicit declaration of function ‘_sys_chdir’
> dbxsys.c: In function ‘sys_getcwd’:
> dbxsys.c:247: warning: implicit declaration of function ‘_sys_getcwd’
> dbxsys.c:247: warning: return makes pointer from integer without a cast
> dbxsys.c: In function ‘sys_delete’:
> dbxsys.c:291: warning: implicit declaration of function ‘unlink’
> dbxsys.c: In function ‘sys_set_time’:
> dbxsys.c:330: warning: implicit declaration of function ‘_sys_set_time’
> make[1]: **\* [dbxsys.o] Error 1
> make: **\* [all] Error 2
