### PR TITLE
Adjust strncpy call to not use string length

### DIFF
--- a/dbxread.c
+++ b/dbxread.c
@@ -51,19 +51,18 @@ static int _dbx_info_cmp(const dbx_info_t *ia, const dbx_info_t *ib)
 
 static char *_dbx_read_string(FILE *file, int offset)
 {
-  char c[256];
+  char c[256] = {};
   char *s = NULL;
   int n = 0;
   int l = 0;
 
   fseek(file, offset, SEEK_SET);
-  c[255]='\0';
 
   do {
     sys_fread(c, 1, 255, file);
     l = strlen(c);
     s = realloc(s, n + l + 1);
-    strncpy(s + n, c, l);
+    memcpy(s + n, c, l);
     n += l;
     s[n] = '\0';
   } while (l == 255);


### PR DESCRIPTION
Gcc doesn't like this:
```
dbxread.c:66:5: error: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
     strncpy(s + n, c, l);
     ^~~~~~~~~~~~~~~~~~~~
dbxread.c:64:9: note: length computed here
     l = strlen(c);
         ^~~~~~~~~
cc1: all warnings being treated as errors
```
Actually the code was OK, but it's nicer to use memcpy() to make it clear
that we don't want the NUL terminator to be copied.

A different bug is corrected: the array c was not initialized, so if a
string shorter than 255 bytes was read, and a NUL byte was was not
present in the bytes read, strlen() would read garbage data from the
heap, in the area between the data read and the 255th byte which was
initalized to NUL.